### PR TITLE
Replacing raw.github.com with raw.githubusercontent.com in docs

### DIFF
--- a/source/dradis_development_101.textile
+++ b/source/dradis_development_101.textile
@@ -62,7 +62,7 @@ h4. RVM and Ruby 1.9.3
 We are going to install Ruby 1.9.3 using "RVM":http://beginrescueend.com/. This has the benefit of keeping everything under your `~/.rvm/` folder:
 
 <shell>
-etd@host:~$ bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
+etd@host:~$ bash -s stable < <(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 etd@host:~$ source ~/.profile
 etd@host:~$ rvm -v
 </shell>

--- a/source/dradis_on_cygwin.textile
+++ b/source/dradis_on_cygwin.textile
@@ -11,7 +11,7 @@ If you already have <a href="http://www.metasploit.com">Metasploit</a> installed
 
 h3. Install the current development branch
 
-For this tutorial, we are going to use the latest version from Dradis' <a href="https://github.com/dradis/dradisframework">git</a> repository. 
+For this tutorial, we are going to use the latest version from Dradis' <a href="https://github.com/dradis/dradisframework">git</a> repository.
 
 Metasploit's Cygwin environment already comes with all the dependencies needed to run Dradis, so getting it up and running will be very easy.
 
@@ -27,9 +27,9 @@ $ git clone https://github.com/dradis/dradisframework.git server<br/>
 Then download the verify, reset and start scripts to your dradis-git/ folder:
 
 <blockquote>
-$ wget https://raw.github.com/dradis/meta/master/verify.sh<br/>
-$ wget https://raw.github.com/dradis/meta/master/reset.sh<br/>
-$ wget https://raw.github.com/dradis/meta/master/start.sh<br/>
+$ wget https://raw.githubusercontent.com/dradis/meta/master/verify.sh<br/>
+$ wget https://raw.githubusercontent.com/dradis/meta/master/reset.sh<br/>
+$ wget https://raw.githubusercontent.com/dradis/meta/master/start.sh<br/>
 $ chmod +x *.sh<br/>
 $ ./verify.sh<br/>
 // follow instructions / install dependencies<br/>
@@ -50,6 +50,6 @@ If instead of the latest development <code>master</code> you would rather use on
 
 <blockquote>
 $ ./verify.sh<br/>
-$ ./reset.sh<br/> 
+$ ./reset.sh<br/>
 $ ./start.sh
 </blockquote>

--- a/source/install_on_backtrack.textile
+++ b/source/install_on_backtrack.textile
@@ -13,7 +13,7 @@ h3. Installing Ruby 1.9.3
 We are going to install Ruby 1.9.3 using "RVM":http://beginrescueend.com/. This has the benefit of keeping everything under your `~/.rvm/` folder:
 
 <shell>
-root@root:~# bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
+root@root:~# bash -s stable < <(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 root@root:~# source /etc/profile.d/rvm.sh
 root@root:~# rvm -v
 </shell>
@@ -56,7 +56,7 @@ We are going to work with the Git version of Dradis which is stable but contains
 root@root:~# cd /pentest/misc/
 root@root:/pentest/misc# mkdir dradis-git && cd dradis-git
 root@root:/pentest/misc/dradis-git# git clone https://github.com/dradis/dradisframework.git server
-root@root:/pentest/misc/dradis-git# for file in verify reset start; do curl -O https://raw.github.com/dradis/meta/master/$file.sh; done
+root@root:/pentest/misc/dradis-git# for file in verify reset start; do curl -O https://raw.githubusercontent.com/dradis/meta/master/$file.sh; done
 root@root:/pentest/misc/dradis-git# chmod +x *.sh
 </shell>
 
@@ -88,9 +88,9 @@ Once you have your copy of the repo, we need to install a few Ruby dependencies:
 
 h3. Preparing Dradis
 
-Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database. 
+Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database.
 
-However, since in BackTrack you typically run as the *root* user, there is a tweak that you have to apply to the `reset.sh` and `start.sh` scripts. 
+However, since in BackTrack you typically run as the *root* user, there is a tweak that you have to apply to the `reset.sh` and `start.sh` scripts.
 
 We will start with `reset.sh`. Replace the RVM load line (around #13) from:
 

--- a/source/install_on_macos.textile
+++ b/source/install_on_macos.textile
@@ -9,7 +9,7 @@ h3. Prerequisites: Ruby 1.9.3
 We are going to install Ruby 1.9.3 using "RVM":http://beginrescueend.com/. This has the benefit of keeping everything under your `~/.rvm/` folder:
 
 <shell>
-etd@host:~$ bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
+etd@host:~$ bash -s stable < <(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 etd@host:~$ source .bash_profile
 etd@host:~$ rvm -v
 </shell>
@@ -41,7 +41,7 @@ We are going to work with the Git version of Dradis which is stable but contains
 etd@host:~$ mkdir dradis-git
 etd@host:~$ cd dradis-git/
 etd@host:~/dradis-git$ git clone https://github.com/dradis/dradisframework.git server
-etd@host:~/dradis-git$ for file in verify reset start; do curl -O https://raw.github.com/dradis/meta/master/$file.sh; done
+etd@host:~/dradis-git$ for file in verify reset start; do curl -O https://raw.githubusercontent.com/dradis/meta/master/$file.sh; done
 etd@host:~/dradis-git$ chmod +x *.sh
 </shell>
 
@@ -73,7 +73,7 @@ Once you have your copy of the repo, we need to install a few Ruby dependencies:
 
 h3. Preparing Dradis
 
-Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database. 
+Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database.
 
 <shell>
 etd@host:~/dradis-git$ ./reset.sh

--- a/source/install_on_ubuntu.textile
+++ b/source/install_on_ubuntu.textile
@@ -29,7 +29,7 @@ h3. Installing Ruby 1.9.3
 We are going to install Ruby 1.9.3 using "RVM":http://beginrescueend.com/. This has the benefit of keeping everything under your `~/.rvm/` folder:
 
 <shell>
-etd@host:~$ bash -s stable < <(curl -s https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
+etd@host:~$ bash -s stable < <(curl -s https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer)
 etd@host:~$ source ~/.profile
 etd@host:~$ rvm -v
 </shell>
@@ -72,7 +72,7 @@ We are going to work with the Git version of Dradis which is stable but contains
 etd@host:~$ mkdir dradis-git
 etd@host:~$ cd dradis-git/
 etd@host:~/dradis-git$ git clone https://github.com/dradis/dradisframework.git server
-etd@host:~/dradis-git$ for file in verify reset start; do curl -O https://raw.github.com/dradis/meta/master/$file.sh; done
+etd@host:~/dradis-git$ for file in verify reset start; do curl -O https://raw.githubusercontent.com/dradis/meta/master/$file.sh; done
 etd@host:~/dradis-git$ chmod +x *.sh
 </shell>
 
@@ -104,7 +104,7 @@ Once you have your copy of the repo, we need to install a few Ruby dependencies:
 
 h3. Preparing Dradis
 
-Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database. 
+Before you can start the server you need to run *./reset.sh* this will prepare the config files for first use and will re-generate the repository database.
 
 <shell>
 etd@host:~/dradis-git$ ./reset.sh


### PR DESCRIPTION
Using raw.github.com makes the curl commands in the docs fail as curl does not follow the redirect given from raw.github.com to raw.githubusercontent.com. 
